### PR TITLE
Add multiple secrets as source at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,23 @@ builder.Configuration.AddSecretsManager(
     c => c.ConfigurationKeyPrefix = "AppSecrets");
 ```
 
+In order to add multiple secrets while sharing same configuration,
+it's possible to use another overload of `AddSecretsManager` method:
+
+```csharp
+// add AWS Secrets Manager Configuration Provider for multiple secrets
+builder.Configuration.AddSecretsManager(["my-first-secret", "my-second-secret"]);
+```
+
 ## Configuration
 
 ### Optional secret
 
-When adding a configuration source, it is mandatory by default - meaning if the secret is not found or it's not possible 
-to load it, an exception is thrown. To make it optional, set `isOptional` to `true`:
+When adding a configuration source, given secret is mandatory by default - meaning if the secret is not found, or it's not possible 
+to fetch it, an exception is thrown. To make it optional, set `IsOptional` property to `true`:
 
 ```csharp
-builder.Configuration.AddSecretsManager("my-secret-secrets", isOptional: true);
+builder.Configuration.AddSecretsManager("my-secret-secrets", c => c.IsOptional = true);
 ```
 
 ### Secret Version
@@ -88,7 +96,7 @@ When binding your option type, make sure path is considered or that you bind to 
 
 ### Secret processing (parsing and tokenizing)
 
-By default AWS Secrets Manager stores secret as simple key-value JSON object - and thus JSON processor is set as default.
+By default, AWS Secrets Manager stores secret as simple key-value JSON object - and thus JSON processor is set as default.
 In some cases, a user may want to specify a custom format, either a complex JSON object or even an XML document.
 
 In order to support such scenarios, it is possible to specify custom secret processor:
@@ -103,13 +111,13 @@ builder.Configuration.AddSecretsManager(
     });
 ```
 
-There's helper class [`SecretsProcessor<T>`](W4k.Extensions.Configuration.Aws.SecretsManager/SecretsProcessor.cs) which
+There's helper class [`SecretProcessor<T>`](W4k.Extensions.Configuration.Aws.SecretsManager/SecretProcessor.cs) which
 can be used to simplify implementation of custom processor (by providing implementation of [`ISecretStringParser<T>`](W4k.Extensions.Configuration.Aws.SecretsManager/Abstractions/ISecretStringParser.cs) and [`IConfigurationTokenizer<T>`](W4k.Extensions.Configuration.Aws.SecretsManager/Abstractions/IConfigurationTokenizer.cs)).
 
 ### Configuration key transformation
 
 It is possible to hook into the configuration key transformation, which is used to transform the tokenized configuration key.
-By default only [`KeyDelimiterTransformer`](W4k.Extensions.Configuration.Aws.SecretsManager/ConfigurationKeyTransformer.cs) is used.
+By default, only [`KeyDelimiterTransformer`](W4k.Extensions.Configuration.Aws.SecretsManager/ConfigurationKeyTransformer.cs) is used.
 
 `KeyDelimiterTransformer` transforms "`__`" to configuration key delimiter, "`:`".
 

--- a/W4k.Extensions.Configuration.Aws.SecretsManager.Tests/SecretsManagerConfigurationProviderShould.cs
+++ b/W4k.Extensions.Configuration.Aws.SecretsManager.Tests/SecretsManagerConfigurationProviderShould.cs
@@ -69,7 +69,7 @@ public class SecretsManagerConfigurationProviderShould
             .Throws(new ResourceNotFoundException("(╯‵□′)╯︵┻━┻"));
 
         var source = new SecretsManagerConfigurationSource(
-            new SecretsManagerConfigurationProviderOptions("le-secret", isOptional: true),
+            new SecretsManagerConfigurationProviderOptions("le-secret") { IsOptional = true },
             secretsManagerStub);
 
         var provider = new SecretsManagerConfigurationProvider(source);

--- a/W4k.Extensions.Configuration.Aws.SecretsManager.Tests/SecretsManagerConfigurationProviderShould.cs
+++ b/W4k.Extensions.Configuration.Aws.SecretsManager.Tests/SecretsManagerConfigurationProviderShould.cs
@@ -28,7 +28,7 @@ public class SecretsManagerConfigurationProviderShould
             .GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
             .Returns(InitialSecretValueResponse);
         
-        var source = new SecretsManagerConfigurationSource(TestOptions, secretsManagerStub, isOptional: false);
+        var source = new SecretsManagerConfigurationSource(TestOptions, secretsManagerStub);
         var provider = new SecretsManagerConfigurationProvider(source);
         
         // act
@@ -47,14 +47,12 @@ public class SecretsManagerConfigurationProviderShould
     public void ThrowWhenLoadingFails()
     {
         // arrange
-        var isOptional = false;
-
         var secretsManagerStub = Substitute.For<IAmazonSecretsManager>();
         secretsManagerStub
             .GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
             .Throws(new ResourceNotFoundException("(╯‵□′)╯︵┻━┻"));
-        
-        var source = new SecretsManagerConfigurationSource(TestOptions, secretsManagerStub, isOptional);
+
+        var source = new SecretsManagerConfigurationSource(TestOptions, secretsManagerStub);
         var provider = new SecretsManagerConfigurationProvider(source);
         
         // act
@@ -65,14 +63,15 @@ public class SecretsManagerConfigurationProviderShould
     public void NotThrowWhenLoadingFailsButSourceIsOptional()
     {
         // arrange
-        var isOptional = true;
-
         var secretsManagerStub = Substitute.For<IAmazonSecretsManager>();
         secretsManagerStub
             .GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
             .Throws(new ResourceNotFoundException("(╯‵□′)╯︵┻━┻"));
-        
-        var source = new SecretsManagerConfigurationSource(TestOptions, secretsManagerStub, isOptional);
+
+        var source = new SecretsManagerConfigurationSource(
+            new SecretsManagerConfigurationProviderOptions("le-secret", isOptional: true),
+            secretsManagerStub);
+
         var provider = new SecretsManagerConfigurationProvider(source);
         
         // act
@@ -99,7 +98,7 @@ public class SecretsManagerConfigurationProviderShould
             .GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
             .Returns(InitialSecretValueResponse, refreshedResponse);
         
-        var source = new SecretsManagerConfigurationSource(TestOptions, secretsManagerStub, isOptional: false);
+        var source = new SecretsManagerConfigurationSource(TestOptions, secretsManagerStub);
         var provider = new SecretsManagerConfigurationProvider(source);
         
         // act
@@ -130,7 +129,7 @@ public class SecretsManagerConfigurationProviderShould
             .GetSecretValueAsync(Arg.Any<GetSecretValueRequest>(), Arg.Any<CancellationToken>())
             .Returns(InitialSecretValueResponse, InitialSecretValueResponse);
         
-        var source = new SecretsManagerConfigurationSource(TestOptions, secretsManagerStub, isOptional: false);
+        var source = new SecretsManagerConfigurationSource(TestOptions, secretsManagerStub);
         var provider = new SecretsManagerConfigurationProvider(source);
         
         // act

--- a/W4k.Extensions.Configuration.Aws.SecretsManager/Abstractions/IConfigurationRefresher.cs
+++ b/W4k.Extensions.Configuration.Aws.SecretsManager/Abstractions/IConfigurationRefresher.cs
@@ -13,6 +13,7 @@ public interface IConfigurationRefresher
     /// <summary>
     /// Gets whether configuration source is optional.
     /// </summary>
+    [Obsolete("Use Options.IsOptional instead.")]
     bool IsOptional { get; }
 
     /// <summary>

--- a/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationProvider.cs
+++ b/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationProvider.cs
@@ -23,7 +23,7 @@ internal sealed class SecretsManagerConfigurationProvider : ConfigurationProvide
     }
 
     public SecretsManagerConfigurationProviderOptions Options => _source.Options;
-    public bool IsOptional => _source.IsOptional;
+    public bool IsOptional => _source.Options.IsOptional;
 
     public override void Load()
     {
@@ -42,7 +42,7 @@ internal sealed class SecretsManagerConfigurationProvider : ConfigurationProvide
         }
         catch
         {
-            if (IsOptional)
+            if (Options.IsOptional)
             {
                 return;
             }

--- a/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationProviderOptions.cs
+++ b/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationProviderOptions.cs
@@ -24,10 +24,21 @@ public sealed class SecretsManagerConfigurationProviderOptions
         SecretName = secretName;
     }
 
+    internal SecretsManagerConfigurationProviderOptions(string secretName, bool isOptional)
+        : this(secretName)
+    {
+        IsOptional = isOptional;
+    }
+
     /// <summary>
     /// Gets secret name (or its complete ARN) to fetch.
     /// </summary>
     public string SecretName { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether secret is mandatory (throws when failed to load) or optional (silently ignores).
+    /// </summary>
+    public bool IsOptional { get; set; }
 
     /// <summary>
     /// Gets or sets secret version to fetch, if not provided, latest version of secret is fetched.

--- a/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationProviderOptions.cs
+++ b/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationProviderOptions.cs
@@ -24,12 +24,6 @@ public sealed class SecretsManagerConfigurationProviderOptions
         SecretName = secretName;
     }
 
-    internal SecretsManagerConfigurationProviderOptions(string secretName, bool isOptional)
-        : this(secretName)
-    {
-        IsOptional = isOptional;
-    }
-
     /// <summary>
     /// Gets secret name (or its complete ARN) to fetch.
     /// </summary>

--- a/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationSource.cs
+++ b/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationSource.cs
@@ -69,7 +69,11 @@ public static class SecretsManagerConfigurationExtensions
         ArgumentNullException.ThrowIfNull(secretName);
         ArgumentNullException.ThrowIfNull(client);
 
-        var providerOptions = new SecretsManagerConfigurationProviderOptions(secretName, isOptional);
+        var providerOptions = new SecretsManagerConfigurationProviderOptions(secretName)
+        {
+            IsOptional = isOptional,
+        };
+
         configureOptions?.Invoke(providerOptions);
 
         return builder.Add(new SecretsManagerConfigurationSource(providerOptions, client));

--- a/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationSource.cs
+++ b/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationSource.cs
@@ -35,7 +35,7 @@ public static class SecretsManagerConfigurationExtensions
     /// <param name="secretName">Secret name or ID.</param>
     /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
     /// <param name="isOptional">Defines the configuration provider's response when a server loading error occurs. If set to false, the error is propagated. If set to true, the error is ignored and no settings are loaded from the AWS Secrets Manager Configuration.</param>
-    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    /// <returns>Instance of <see cref="IConfigurationBuilder"/>.</returns>
     [SuppressMessage("ReSharper", "MethodOverloadWithOptionalParameter", Justification = "Binary compatibility.")]
     [Obsolete("Use override without `isOptional` parameter, AddSecretsManager(IConfigurationBuilder, string, Action<SecretsManagerConfigurationProviderOptions>).")]
     public static IConfigurationBuilder AddSecretsManager(
@@ -56,7 +56,9 @@ public static class SecretsManagerConfigurationExtensions
     /// <param name="client">AWS Secrets Manager client.</param>
     /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
     /// <param name="isOptional">Defines the configuration provider's response when a server loading error occurs. If set to false, the error is propagated. If set to true, the error is ignored and no settings are loaded from the AWS Secrets Manager Configuration.</param>
-    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    /// <returns>Instance of <see cref="IConfigurationBuilder"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="secretName"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="client"/> is <see langword="null"/>.</exception>
     [SuppressMessage("ReSharper", "MethodOverloadWithOptionalParameter", Justification = "Binary compatibility.")]
     [Obsolete("Use override without `isOptional` parameter, AddSecretsManager(IConfigurationBuilder, string, IAmazonSecretsManager, Action<SecretsManagerConfigurationProviderOptions>).")]
     public static IConfigurationBuilder AddSecretsManager(
@@ -88,7 +90,7 @@ public static class SecretsManagerConfigurationExtensions
     /// <param name="builder">Configuration builder.</param>
     /// <param name="secretName">Secret name or ID.</param>
     /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
-    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    /// <returns>Instance of <see cref="IConfigurationBuilder"/>.</returns>
     public static IConfigurationBuilder AddSecretsManager(
         this IConfigurationBuilder builder,
         string secretName,
@@ -105,7 +107,9 @@ public static class SecretsManagerConfigurationExtensions
     /// <param name="secretName">Secret name or ID.</param>
     /// <param name="client">AWS Secrets Manager client.</param>
     /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
-    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    /// <returns>Instance of <see cref="IConfigurationBuilder"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="secretName"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="client"/> is <see langword="null"/>.</exception>
     public static IConfigurationBuilder AddSecretsManager(
         this IConfigurationBuilder builder,
         string secretName,
@@ -130,7 +134,7 @@ public static class SecretsManagerConfigurationExtensions
     /// <param name="builder">Configuration builder.</param>
     /// <param name="secretNames">Collection of secret names to fetch from AWS Secrets Manager.</param>
     /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
-    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    /// <returns>Instance of <see cref="IConfigurationBuilder"/>.</returns>
     public static IConfigurationBuilder AddSecretsManager(
         this IConfigurationBuilder builder,
         IReadOnlyList<string> secretNames,
@@ -147,7 +151,9 @@ public static class SecretsManagerConfigurationExtensions
     /// <param name="secretNames">Collection of secret names to fetch from AWS Secrets Manager.</param>
     /// <param name="client">AWS Secrets Manager client.</param>
     /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
-    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    /// <returns>Instance of <see cref="IConfigurationBuilder"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="secretNames"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="secretNames"/> is empty.</exception>
     public static IConfigurationBuilder AddSecretsManager(
         this IConfigurationBuilder builder,
         IReadOnlyList<string> secretNames,

--- a/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationSource.cs
+++ b/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationSource.cs
@@ -1,4 +1,6 @@
-﻿using Amazon.SecretsManager;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Amazon.SecretsManager;
 using Microsoft.Extensions.Configuration;
 
 namespace W4k.Extensions.Configuration.Aws.SecretsManager;
@@ -53,6 +55,27 @@ public static class SecretsManagerConfigurationExtensions
     /// <summary>
     /// Adds secrets manager as configuration source.
     /// </summary>
+    /// <remarks>
+    /// This extension methods uses default <see cref="AmazonSecretsManagerClient"/> instance.
+    /// </remarks>
+    /// <param name="builder">Configuration builder.</param>
+    /// <param name="secretNames">Collection of secret names to fetch from AWS Secrets Manager.</param>
+    /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
+    /// <param name="isOptional">Defines the configuration provider's response when a server loading error occurs. If set to false, the error is propagated. If set to true, the error is ignored and no settings are loaded from the AWS Secrets Manager Configuration.</param>
+    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    public static IConfigurationBuilder AddSecretsManager(
+        this IConfigurationBuilder builder,
+        IReadOnlyCollection<string> secretNames,
+        Action<SecretsManagerConfigurationProviderOptions>? configureOptions = null,
+        bool isOptional = false)
+    {
+        var client = new AmazonSecretsManagerClient();
+        return builder.AddSecretsManager(secretNames, client, configureOptions, isOptional);
+    }
+
+    /// <summary>
+    /// Adds secrets manager as configuration source.
+    /// </summary>
     /// <param name="builder">Configuration builder.</param>
     /// <param name="secretName">Secret name or ID.</param>
     /// <param name="client">AWS Secrets Manager client.</param>
@@ -73,5 +96,48 @@ public static class SecretsManagerConfigurationExtensions
         configureOptions?.Invoke(providerOptions);
 
         return builder.Add(new SecretsManagerConfigurationSource(providerOptions, client, isOptional));
+    }
+
+    /// <summary>
+    /// Adds secrets manager as configuration source.
+    /// </summary>
+    /// <param name="builder">Configuration builder.</param>
+    /// <param name="secretNames">Collection of secret names to fetch from AWS Secrets Manager.</param>
+    /// <param name="client">AWS Secrets Manager client.</param>
+    /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
+    /// <param name="isOptional">Defines the configuration provider's response when a server loading error occurs. If set to false, the error is propagated. If set to true, the error is ignored and no settings are loaded from the AWS Secrets Manager Configuration.</param>
+    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    public static IConfigurationBuilder AddSecretsManager(
+        this IConfigurationBuilder builder,
+        IReadOnlyCollection<string> secretNames,
+        IAmazonSecretsManager client,
+        Action<SecretsManagerConfigurationProviderOptions>? configureOptions = null,
+        bool isOptional = false)
+    {
+        ArgumentNullException.ThrowIfNull(secretNames);
+        ArgumentNullException.ThrowIfNull(client);
+
+        if (secretNames.Count == 0)
+        {
+            ThrowOnEmptySecretNames(secretNames);
+        }
+
+        foreach (var secretName in secretNames)
+        {
+            var providerOptions = new SecretsManagerConfigurationProviderOptions(secretName);
+            configureOptions?.Invoke(providerOptions);
+
+            builder.Add(new SecretsManagerConfigurationSource(providerOptions, client, isOptional));
+        }
+
+        return builder;
+    }
+
+    [DoesNotReturn]
+    private static void ThrowOnEmptySecretNames(
+        IReadOnlyCollection<string> secretNames,
+        [CallerArgumentExpression("secretNames")] string? paramName = null)
+    {
+        throw new ArgumentException("At least one secret name must be provided.", paramName);
     }
 }

--- a/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationSource.cs
+++ b/W4k.Extensions.Configuration.Aws.SecretsManager/SecretsManagerConfigurationSource.cs
@@ -7,20 +7,14 @@ namespace W4k.Extensions.Configuration.Aws.SecretsManager;
 
 internal class SecretsManagerConfigurationSource : IConfigurationSource
 {
-    public SecretsManagerConfigurationSource(
-        SecretsManagerConfigurationProviderOptions options,
-        IAmazonSecretsManager client,
-        bool isOptional)
+    public SecretsManagerConfigurationSource(SecretsManagerConfigurationProviderOptions options, IAmazonSecretsManager client)
     {
         Options = options;
         SecretsManager = client;
-        IsOptional = isOptional;
     }
-
 
     public SecretsManagerConfigurationProviderOptions Options { get; }
     public IAmazonSecretsManager SecretsManager { get; }
-    public bool IsOptional { get; }
 
     public IConfigurationProvider Build(IConfigurationBuilder builder) =>
         new SecretsManagerConfigurationProvider(this);
@@ -42,6 +36,8 @@ public static class SecretsManagerConfigurationExtensions
     /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
     /// <param name="isOptional">Defines the configuration provider's response when a server loading error occurs. If set to false, the error is propagated. If set to true, the error is ignored and no settings are loaded from the AWS Secrets Manager Configuration.</param>
     /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    [SuppressMessage("ReSharper", "MethodOverloadWithOptionalParameter", Justification = "Binary compatibility.")]
+    [Obsolete("Use override without `isOptional` parameter, AddSecretsManager(IConfigurationBuilder, string, Action<SecretsManagerConfigurationProviderOptions>).")]
     public static IConfigurationBuilder AddSecretsManager(
         this IConfigurationBuilder builder,
         string secretName,
@@ -55,33 +51,14 @@ public static class SecretsManagerConfigurationExtensions
     /// <summary>
     /// Adds secrets manager as configuration source.
     /// </summary>
-    /// <remarks>
-    /// This extension methods uses default <see cref="AmazonSecretsManagerClient"/> instance.
-    /// </remarks>
-    /// <param name="builder">Configuration builder.</param>
-    /// <param name="secretNames">Collection of secret names to fetch from AWS Secrets Manager.</param>
-    /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
-    /// <param name="isOptional">Defines the configuration provider's response when a server loading error occurs. If set to false, the error is propagated. If set to true, the error is ignored and no settings are loaded from the AWS Secrets Manager Configuration.</param>
-    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
-    public static IConfigurationBuilder AddSecretsManager(
-        this IConfigurationBuilder builder,
-        IReadOnlyCollection<string> secretNames,
-        Action<SecretsManagerConfigurationProviderOptions>? configureOptions = null,
-        bool isOptional = false)
-    {
-        var client = new AmazonSecretsManagerClient();
-        return builder.AddSecretsManager(secretNames, client, configureOptions, isOptional);
-    }
-
-    /// <summary>
-    /// Adds secrets manager as configuration source.
-    /// </summary>
     /// <param name="builder">Configuration builder.</param>
     /// <param name="secretName">Secret name or ID.</param>
     /// <param name="client">AWS Secrets Manager client.</param>
     /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
     /// <param name="isOptional">Defines the configuration provider's response when a server loading error occurs. If set to false, the error is propagated. If set to true, the error is ignored and no settings are loaded from the AWS Secrets Manager Configuration.</param>
     /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    [SuppressMessage("ReSharper", "MethodOverloadWithOptionalParameter", Justification = "Binary compatibility.")]
+    [Obsolete("Use override without `isOptional` parameter, AddSecretsManager(IConfigurationBuilder, string, IAmazonSecretsManager, Action<SecretsManagerConfigurationProviderOptions>).")]
     public static IConfigurationBuilder AddSecretsManager(
         this IConfigurationBuilder builder,
         string secretName,
@@ -91,11 +68,72 @@ public static class SecretsManagerConfigurationExtensions
     {
         ArgumentNullException.ThrowIfNull(secretName);
         ArgumentNullException.ThrowIfNull(client);
-        
+
+        var providerOptions = new SecretsManagerConfigurationProviderOptions(secretName, isOptional);
+        configureOptions?.Invoke(providerOptions);
+
+        return builder.Add(new SecretsManagerConfigurationSource(providerOptions, client));
+    }
+
+    /// <summary>
+    /// Adds secrets manager as configuration source.
+    /// </summary>
+    /// <remarks>
+    /// This extension methods uses default <see cref="AmazonSecretsManagerClient"/> instance.
+    /// </remarks>
+    /// <param name="builder">Configuration builder.</param>
+    /// <param name="secretName">Secret name or ID.</param>
+    /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
+    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    public static IConfigurationBuilder AddSecretsManager(
+        this IConfigurationBuilder builder,
+        string secretName,
+        Action<SecretsManagerConfigurationProviderOptions>? configureOptions = null)
+    {
+        var client = new AmazonSecretsManagerClient();
+        return builder.AddSecretsManager(secretName, client, configureOptions);
+    }
+
+    /// <summary>
+    /// Adds secrets manager as configuration source.
+    /// </summary>
+    /// <param name="builder">Configuration builder.</param>
+    /// <param name="secretName">Secret name or ID.</param>
+    /// <param name="client">AWS Secrets Manager client.</param>
+    /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
+    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    public static IConfigurationBuilder AddSecretsManager(
+        this IConfigurationBuilder builder,
+        string secretName,
+        IAmazonSecretsManager client,
+        Action<SecretsManagerConfigurationProviderOptions>? configureOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(secretName);
+        ArgumentNullException.ThrowIfNull(client);
+
         var providerOptions = new SecretsManagerConfigurationProviderOptions(secretName);
         configureOptions?.Invoke(providerOptions);
 
-        return builder.Add(new SecretsManagerConfigurationSource(providerOptions, client, isOptional));
+        return builder.Add(new SecretsManagerConfigurationSource(providerOptions, client));
+    }
+
+    /// <summary>
+    /// Adds secrets manager as configuration source.
+    /// </summary>
+    /// <remarks>
+    /// This extension methods uses default <see cref="AmazonSecretsManagerClient"/> instance.
+    /// </remarks>
+    /// <param name="builder">Configuration builder.</param>
+    /// <param name="secretNames">Collection of secret names to fetch from AWS Secrets Manager.</param>
+    /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
+    /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
+    public static IConfigurationBuilder AddSecretsManager(
+        this IConfigurationBuilder builder,
+        IReadOnlyCollection<string> secretNames,
+        Action<SecretsManagerConfigurationProviderOptions>? configureOptions = null)
+    {
+        var client = new AmazonSecretsManagerClient();
+        return builder.AddSecretsManager(secretNames, client, configureOptions);
     }
 
     /// <summary>
@@ -105,14 +143,12 @@ public static class SecretsManagerConfigurationExtensions
     /// <param name="secretNames">Collection of secret names to fetch from AWS Secrets Manager.</param>
     /// <param name="client">AWS Secrets Manager client.</param>
     /// <param name="configureOptions">A delegate that is invoked to set up the AWS Secrets Manager Configuration options.</param>
-    /// <param name="isOptional">Defines the configuration provider's response when a server loading error occurs. If set to false, the error is propagated. If set to true, the error is ignored and no settings are loaded from the AWS Secrets Manager Configuration.</param>
     /// <returns>Instance of <see cref="IConfigurationBuilder"/></returns>
     public static IConfigurationBuilder AddSecretsManager(
         this IConfigurationBuilder builder,
         IReadOnlyCollection<string> secretNames,
         IAmazonSecretsManager client,
-        Action<SecretsManagerConfigurationProviderOptions>? configureOptions = null,
-        bool isOptional = false)
+        Action<SecretsManagerConfigurationProviderOptions>? configureOptions = null)
     {
         ArgumentNullException.ThrowIfNull(secretNames);
         ArgumentNullException.ThrowIfNull(client);
@@ -127,7 +163,7 @@ public static class SecretsManagerConfigurationExtensions
             var providerOptions = new SecretsManagerConfigurationProviderOptions(secretName);
             configureOptions?.Invoke(providerOptions);
 
-            builder.Add(new SecretsManagerConfigurationSource(providerOptions, client, isOptional));
+            builder.Add(new SecretsManagerConfigurationSource(providerOptions, client));
         }
 
         return builder;


### PR DESCRIPTION
Adding overload to register "Secrets Manager" configuration source with multiple secrets (instead of calling `Add...` multiple times).